### PR TITLE
feat: AddBusNameStampMiddleware

### DIFF
--- a/example/basic-config.php
+++ b/example/basic-config.php
@@ -7,7 +7,6 @@ namespace App;
 return [
     // phpcs:disable
     'dependencies' => [
-        'factories' => [],
     ],
 
     'messenger' => [
@@ -17,6 +16,7 @@ return [
                 'allows_no_handler' => false,
                 'handlers'          => [],
                 'middleware'        => [
+                    'messenger.command.middleware.add_bus_stamp',
                     'messenger.command.middleware.handler',
                 ],
                 'routes'            => [],

--- a/src/ConfigProvider.php
+++ b/src/ConfigProvider.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Xtreamwayz\PsrContainerMessenger;
 
 use Symfony\Component\Messenger\Command\ConsumeMessagesCommand;
+use Xtreamwayz\PsrContainerMessenger\Container\AddBusNameStampMiddlewareFactory;
 use Xtreamwayz\PsrContainerMessenger\Container\HandleMessageMiddlewareFactory;
 use Xtreamwayz\PsrContainerMessenger\Container\MessageBusFactory;
 use Xtreamwayz\PsrContainerMessenger\Container\SendMessageMiddlewareFactory;
@@ -38,6 +39,8 @@ class ConfigProvider
                 'messenger.query.bus'                => [MessageBusFactory::class, 'messenger.query.bus'],
                 'messenger.query.middleware.handler' => [HandleMessageMiddlewareFactory::class, 'messenger.query.bus'],
                 'messenger.query.middleware.sender'  => [SendMessageMiddlewareFactory::class, 'messenger.query.bus'],
+
+                'messenger.command.middleware.add_bus_stamp' => [AddBusNameStampMiddlewareFactory::class, 'messenger.command.bus'],
             ],
         ];
         // phpcs:enable

--- a/src/Container/AddBusNameStampMiddlewareFactory.php
+++ b/src/Container/AddBusNameStampMiddlewareFactory.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Xtreamwayz\PsrContainerMessenger\Container;
+
+use Psr\Container\ContainerInterface;
+use Symfony\Component\Messenger\Middleware\AddBusNameStampMiddleware;
+
+final class AddBusNameStampMiddlewareFactory
+{
+    private string $busName;
+
+    private function __construct(string $busName)
+    {
+        $this->busName = $busName;
+    }
+
+    public static function __callStatic(string $name, array $arguments): AddBusNameStampMiddleware
+    {
+        if (!isset($arguments[0]) || !$arguments[0] instanceof ContainerInterface) {
+            throw new \InvalidArgumentException(
+                sprintf('The first argument must be of type %s', ContainerInterface::class)
+            );
+        }
+
+        return (new static($name))->__invoke($arguments[0]);
+    }
+
+    public function __invoke(ContainerInterface $container): AddBusNameStampMiddleware
+    {
+        if (!$container->has($this->busName)) {
+            throw new \InvalidArgumentException(sprintf('No service with name %s found', $this->busName));
+        }
+
+        return new AddBusNameStampMiddleware($this->busName);
+    }
+}

--- a/src/Container/AddBusNameStampMiddlewareFactory.php
+++ b/src/Container/AddBusNameStampMiddlewareFactory.php
@@ -4,8 +4,11 @@ declare(strict_types=1);
 
 namespace Xtreamwayz\PsrContainerMessenger\Container;
 
+use InvalidArgumentException;
 use Psr\Container\ContainerInterface;
 use Symfony\Component\Messenger\Middleware\AddBusNameStampMiddleware;
+
+use function sprintf;
 
 final class AddBusNameStampMiddlewareFactory
 {
@@ -18,8 +21,8 @@ final class AddBusNameStampMiddlewareFactory
 
     public static function __callStatic(string $name, array $arguments): AddBusNameStampMiddleware
     {
-        if (!isset($arguments[0]) || !$arguments[0] instanceof ContainerInterface) {
-            throw new \InvalidArgumentException(
+        if (! isset($arguments[0]) || ! $arguments[0] instanceof ContainerInterface) {
+            throw new InvalidArgumentException(
                 sprintf('The first argument must be of type %s', ContainerInterface::class)
             );
         }
@@ -29,8 +32,8 @@ final class AddBusNameStampMiddlewareFactory
 
     public function __invoke(ContainerInterface $container): AddBusNameStampMiddleware
     {
-        if (!$container->has($this->busName)) {
-            throw new \InvalidArgumentException(sprintf('No service with name %s found', $this->busName));
+        if (! $container->has($this->busName)) {
+            throw new InvalidArgumentException(sprintf('No service with name %s found', $this->busName));
         }
 
         return new AddBusNameStampMiddleware($this->busName);

--- a/test/ConfigProviderTest.php
+++ b/test/ConfigProviderTest.php
@@ -64,7 +64,6 @@ class ConfigProviderTest extends TestCase
     {
         // Get dependencies
         $dependencies = $this->provider->getDependencies();
-
         // Mock dependencies
         $dependencies['services'][LoggerInterface::class] = $this->createMock(LoggerInterface::class);
 


### PR DESCRIPTION
Is your feature request related to a problem? Please describe.
In symfony/messenger at version 4.3 a new middleware called AddBusNameStampMiddleware was added.
You need to add this middleware to your bus to handle async messanges properly.
The middleware needs bus name as constructor dependency.

Describe the solution you'd like
Adding a static factory for the AddBusNameStampMiddleware.

closes #30 